### PR TITLE
Step 7に対する変更を提案

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ import { useGetCalenderListQuery, useGetDepartmentQuery, useGetEmployeesQuery } 
       where: {
         department_id: employeesData?.Employees?.department_id
       }
+    },
+    {
+      enabled: !isLoadingEmployees
     }
   )
   const departmentName = deparmentData?.Department?.department_name

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,9 +14,6 @@ import { PrismaModule } from './prisma/prisma.module';
       driver: ApolloDriver,
       playground:true,
       autoSchemaFile: join(process.cwd(), 'schema.graphql'),
-      cors: { 
-        origin: "*"
-      },
     }),
     PrismaModule, 
     DatabaseModule],

--- a/backend/src/database/daily_itemized_reports/daily_itemized_reports.resolver.ts
+++ b/backend/src/database/daily_itemized_reports/daily_itemized_reports.resolver.ts
@@ -1,46 +1,79 @@
 import {
-    CreateOnedailyItemizedReportsArgs,
-    DeleteOnedailyItemizedReportsArgs,
-    FindFirstdailyItemizedReportsArgs,
-    FindManydailyItemizedReportsArgs,
-    FindUniquedailyItemizedReportsArgs,
-    daily_itemized_reports,
-    UpdateOnedailyItemizedReportsArgs,
+  CreateOnedailyItemizedReportsArgs,
+  DeleteOnedailyItemizedReportsArgs,
+  FindFirstdailyItemizedReportsArgs,
+  FindManydailyItemizedReportsArgs,
+  FindUniquedailyItemizedReportsArgs,
+  daily_itemized_reports,
+  UpdateOnedailyItemizedReportsArgs,
 } from '../../@generated/prisma-nestjs-graphql/index';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { DailyItemizedReportsService } from './daily_itemized_reports.service';
+import { Prisma } from '@prisma/client';
 
 @Resolver()
 export class DailyItemizedReportsResolver {
   constructor(private readonly service: DailyItemizedReportsService) {}
 
-  @Query(() => daily_itemized_reports, { name: 'DailyItemizedReports', nullable: true })
+  @Query(() => daily_itemized_reports, {
+    name: 'DailyItemizedReports',
+    nullable: true,
+  })
   async DailyItemizedReports(@Args() args: FindUniquedailyItemizedReportsArgs) {
-    return this.service.findUnique({ ...args });
+    return this.service.findUnique({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindUniqueArgs);
   }
 
-  @Query(() => daily_itemized_reports, { name: 'DailyItemizedReportsFirst', nullable: true })
-  async dailyItemizedReportsFirst(@Args() args: FindFirstdailyItemizedReportsArgs) {
-    return this.service.findFirst({ ...args });
+  @Query(() => daily_itemized_reports, {
+    name: 'DailyItemizedReportsFirst',
+    nullable: true,
+  })
+  async dailyItemizedReportsFirst(
+    @Args() args: FindFirstdailyItemizedReportsArgs,
+  ) {
+    return this.service.findFirst({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindFirstArgs);
   }
 
   @Query(() => [daily_itemized_reports], { name: 'DailyItemizedReportsList' })
-  async dailyItemizedReportsList(@Args() args: FindManydailyItemizedReportsArgs) {
-    return this.service.findMany({ ...args });
+  async dailyItemizedReportsList(
+    @Args() args: FindManydailyItemizedReportsArgs,
+  ) {
+    return this.service.findMany({
+      ...args,
+    } as Prisma.daily_itemized_reportsFindManyArgs);
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'CreateDailyItemizedReports' })
-  async createDailyItemizedReports(@Args() args: CreateOnedailyItemizedReportsArgs) {
+  @Mutation(() => daily_itemized_reports, {
+    name: 'CreateDailyItemizedReports',
+  })
+  async createDailyItemizedReports(
+    @Args() args: CreateOnedailyItemizedReportsArgs,
+  ) {
     return this.service.create({ ...args });
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'UpdateDailyItemizedReports' })
-  async updateDailyItemizedReports(@Args() args: UpdateOnedailyItemizedReportsArgs) {
-    return this.service.update({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'UpdateDailyItemizedReports',
+  })
+  async updateDailyItemizedReports(
+    @Args() args: UpdateOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.update({
+      ...args,
+    } as Prisma.daily_itemized_reportsUpdateArgs);
   }
 
-  @Mutation(() => daily_itemized_reports, { name: 'DeleteDailyItemizedReports' })
-  async deleteDailyItemizedReports(@Args() args: DeleteOnedailyItemizedReportsArgs) {
-    return this.service.delete({ ...args });
+  @Mutation(() => daily_itemized_reports, {
+    name: 'DeleteDailyItemizedReports',
+  })
+  async deleteDailyItemizedReports(
+    @Args() args: DeleteOnedailyItemizedReportsArgs,
+  ) {
+    return this.service.delete({
+      ...args,
+    } as Prisma.daily_itemized_reportsDeleteArgs);
   }
 }

--- a/backend/src/database/daily_reports/daily_reports.resolver.ts
+++ b/backend/src/database/daily_reports/daily_reports.resolver.ts
@@ -1,14 +1,15 @@
 import {
-    CreateOnedailyReportsArgs,
-    DeleteOnedailyReportsArgs,
-    FindFirstdailyReportsArgs,
-    FindManydailyReportsArgs,
-    FindUniquedailyReportsArgs,
-    daily_reports,
-    UpdateOnedailyReportsArgs,
+  CreateOnedailyReportsArgs,
+  DeleteOnedailyReportsArgs,
+  FindFirstdailyReportsArgs,
+  FindManydailyReportsArgs,
+  FindUniquedailyReportsArgs,
+  daily_reports,
+  UpdateOnedailyReportsArgs,
 } from '../../@generated/prisma-nestjs-graphql/index';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { DailyReportsService } from './daily_reports.service';
+import { Prisma } from '@prisma/client';
 
 @Resolver()
 export class DailyReportsResolver {
@@ -16,17 +17,23 @@ export class DailyReportsResolver {
 
   @Query(() => daily_reports, { name: 'DailyReports', nullable: true })
   async DailyReports(@Args() args: FindUniquedailyReportsArgs) {
-    return this.service.findUnique({ ...args });
+    return this.service.findUnique({
+      ...args,
+    } as Prisma.daily_reportsFindUniqueArgs);
   }
 
   @Query(() => daily_reports, { name: 'DailyReportsFirst', nullable: true })
   async dailyReportsFirst(@Args() args: FindFirstdailyReportsArgs) {
-    return this.service.findFirst({ ...args });
+    return this.service.findFirst({
+      ...args,
+    } as Prisma.daily_reportsFindFirstArgs);
   }
 
   @Query(() => [daily_reports], { name: 'DailyReportsList' })
   async dailyReportsList(@Args() args: FindManydailyReportsArgs) {
-    return this.service.findMany({ ...args });
+    return this.service.findMany({
+      ...args,
+    } as Prisma.daily_reportsFindManyArgs);
   }
 
   @Mutation(() => daily_reports, { name: 'CreateDailyReports' })
@@ -36,11 +43,11 @@ export class DailyReportsResolver {
 
   @Mutation(() => daily_reports, { name: 'UpdateDailyReports' })
   async updateDailyReports(@Args() args: UpdateOnedailyReportsArgs) {
-    return this.service.update({ ...args });
+    return this.service.update({ ...args } as Prisma.daily_reportsUpdateArgs);
   }
 
   @Mutation(() => daily_reports, { name: 'DeleteDailyReports' })
   async deleteDailyReports(@Args() args: DeleteOnedailyReportsArgs) {
-    return this.service.delete({ ...args });
+    return this.service.delete({ ...args } as Prisma.daily_reportsDeleteArgs);
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(env.PORT);
 }
 bootstrap();

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -12,7 +12,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   }
 
   async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
+    process.on('beforeExit', async () => {
       await app.close();
     });
   }

--- a/frontend/pages/main/[employees_id].tsx
+++ b/frontend/pages/main/[employees_id].tsx
@@ -33,6 +33,9 @@ const MainPage: NextPage = () => {
       where: {
         department_id: employeesData?.Employees?.department_id
       }
+    },
+    {
+      enabled: !isLoadingEmployees
     }
   )
   const departmentName = deparmentData?.Department?.department_name


### PR DESCRIPTION
## 📝変更の目的/背景
2023/8実施のハンズオンで詰まった箇所について、手順を最新化したい。
## 🔨変更内容

**1. 「README.md」の修正**

- 「組織の取得」で編集するデータ取得部分のコードを修正（STEP-8からソース上修正されていたもの）

**2.「[employees_id].tsx」の修正**
→`useGetDepartmentQuery`の引数に`enabled`を追加

**3. 直前までのstep修正内容を反映**
- 「prisma.service.ts」の修正
- 「daily_itemized_reports.resolver.ts」の修正
- 「daily_reports.resolver.ts」の修正
- 「main.ts」の修正
- 「app.module.ts」の修正